### PR TITLE
fix: use ghcr instead of dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See Dockerfile.build for instructions on bumping this.
-FROM ewjoachim/python-coverage-comment-action-base:v6
+FROM ghcr.io/py-cov-action/python-coverage-comment-action-base:v6
 
 COPY coverage_comment ./coverage_comment
 RUN md5sum -c pyproject.toml.md5 || pip install -e .


### PR DESCRIPTION
Use GHCR instead of Dockerhub to avoid the super-low unauthenticated pulls from dockerhub.
It appears as if the is [already usage](https://github.com/zMynxx/python-coverage-comment-action/blob/12a1e7afe78d3fda49214c5a96ea10d4de339917/.github/workflows/release.yml#L43C1-L43C73) of GHCR in the original repository, just need to:
- [ ] Set the package config to public (org owner)
- [x] Change the `FROM` notation to use the ghcr image (done)
- [x] Notify users